### PR TITLE
V19

### DIFF
--- a/H2_AutoAuction/Classes/Vehicles/PrivatePersonalCar.cs
+++ b/H2_AutoAuction/Classes/Vehicles/PrivatePersonalCar.cs
@@ -19,8 +19,8 @@ public class PrivatePersonalCar : PersonalCar
             trunkDimensions)
     {
         // V19 - PrivatePersonalCar constructor. DriversLicense should be 'B'
-        if (DriversLicense != DriversLicenseEnum.B && hasIsofixFittings)
-            throw new NotImplementedException(); //Exception thrown if DriversLicense is not 'B'
+        if (DriversLicense != DriversLicenseEnum.B && !hasIsofixFittings)
+            throw new NotImplementedException("DriversLicense is not of type'B' or Doesn't have IsofixFittings ");
 
         Name = name;
         Km = km;


### PR DESCRIPTION
## [Checks the type DriverLicese and IsoFix](https://github.com/BastianAsmussen/H2_AutoAuction/commit/343746a0843a7a188b7183d4b014ba40ea717e23)

An Exception is thrown if the given :
* Driver Lisence is not of Type *B*
* The car does not have  an *isofix fitting*


## [Initialised properties](https://github.com/BastianAsmussen/H2_AutoAuction/commit/36605cf0f80e864fa34cf106101cd62a2c9d6dbb)

All given inputes are set both in the PrivatePersonalCar class and in the base class 

